### PR TITLE
move common code into  common module and use ssh-config command to discover hostname for winrm

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -20,6 +20,7 @@ require 'fileutils'
 require 'rubygems/version'
 
 require 'kitchen'
+require 'kitchen/driver/vagrant_common'
 
 module Kitchen
 
@@ -115,68 +116,7 @@ module Kitchen
 
       protected
 
-      WEBSITE = "http://downloads.vagrantup.com/"
-      MIN_VER = "1.1.0"
-
-      def run(cmd, options = {})
-        cmd = "echo #{cmd}" if config[:dry_run]
-        run_command(cmd, { :cwd => vagrant_root }.merge(options))
-      end
-
-      def silently_run(cmd)
-        run_command(cmd,
-          :live_stream => nil, :quiet => logger.debug? ? false : true)
-      end
-
-      def run_pre_create_command
-        if config[:pre_create_command]
-          run(config[:pre_create_command], :cwd => config[:kitchen_root])
-        end
-      end
-
-      def vagrant_root
-        @vagrant_root ||= File.join(
-          config[:kitchen_root], %w{.kitchen kitchen-vagrant}, instance.name
-        )
-      end
-
-      def create_vagrantfile
-        return if @vagrantfile_created
-
-        finalize_synced_folder_config
-
-        vagrantfile = File.join(vagrant_root, "Vagrantfile")
-        debug("Creating Vagrantfile for #{instance.to_str} (#{vagrantfile})")
-        FileUtils.mkdir_p(vagrant_root)
-        File.open(vagrantfile, "wb") { |f| f.write(render_template) }
-        debug_vagrantfile(vagrantfile)
-        @vagrantfile_created = true
-      end
-
-      def finalize_synced_folder_config
-        config[:synced_folders].map! do |source, destination, options|
-          [
-            File.expand_path(
-              source.gsub("%{instance_name}", instance.name),
-              config[:kitchen_root]
-            ),
-            destination.gsub("%{instance_name}", instance.name),
-            options || "nil"
-          ]
-        end
-      end
-
-      def render_template
-        if File.exists?(template)
-          ERB.new(IO.read(template)).result(binding).gsub(%r{^\s*$\n}, '')
-        else
-          raise ActionFailed, "Could not find Vagrantfile template #{template}"
-        end
-      end
-
-      def template
-        File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
-      end
+      include Kitchen::Driver::VagrantCommon
 
       def set_ssh_state(state)
         hash = vagrant_ssh_config
@@ -185,50 +125,6 @@ module Kitchen
         state[:username] = hash["User"]
         state[:ssh_key] = hash["IdentityFile"]
         state[:port] = hash["Port"]
-      end
-
-      def vagrant_ssh_config
-        output = run("vagrant ssh-config", :live_stream => nil)
-        lines = output.split("\n").map do |line|
-          tokens = line.strip.partition(" ")
-          [tokens.first, tokens.last.gsub(/"/, '')]
-        end
-        Hash[lines]
-      end
-
-      def debug_vagrantfile(vagrantfile)
-        if logger.debug?
-          debug("------------")
-          IO.read(vagrantfile).each_line { |l| debug("#{l.chomp}") }
-          debug("------------")
-        end
-      end
-
-      def resolve_config!
-        unless config[:vagrantfile_erb].nil?
-          config[:vagrantfile_erb] =
-            File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
-        end
-        unless config[:pre_create_command].nil?
-          config[:pre_create_command] =
-            config[:pre_create_command].gsub("{{vagrant_root}}", vagrant_root)
-        end
-      end
-
-      def vagrant_version
-        version_string = silently_run("vagrant --version")
-        version_string = version_string.chomp.split(" ").last
-      rescue Errno::ENOENT
-        raise UserError, "Vagrant #{MIN_VER} or higher is not installed." +
-          " Please download a package from #{WEBSITE}."
-      end
-
-      def check_vagrant_version
-        version = vagrant_version
-        if Gem::Version.new(version) < Gem::Version.new(MIN_VER)
-          raise UserError, "Detected an old version of Vagrant (#{version})." +
-            " Please upgrade to version #{MIN_VER} or higher from #{WEBSITE}."
-        end
       end
     end
   end

--- a/lib/kitchen/driver/vagrant_common.rb
+++ b/lib/kitchen/driver/vagrant_common.rb
@@ -1,0 +1,113 @@
+module Kitchen
+  module Driver
+    module VagrantCommon
+
+      WEBSITE = "http://downloads.vagrantup.com/"
+      MIN_VER = "1.1.0"
+
+      def run(cmd, options = {})
+        cmd = "echo #{cmd}" if config[:dry_run]
+        run_command(cmd, { :cwd => vagrant_root }.merge(options))
+      end
+
+      def silently_run(cmd)
+        run_command(cmd,
+          :live_stream => nil, :quiet => logger.debug? ? false : true)
+      end
+
+      def run_pre_create_command
+        if config[:pre_create_command]
+          run(config[:pre_create_command], :cwd => config[:kitchen_root])
+        end
+      end
+
+      def vagrant_root
+        @vagrant_root ||= File.join(
+          config[:kitchen_root], %w{.kitchen kitchen-vagrant}, instance.name
+        )
+      end
+
+      def create_vagrantfile
+        return if @vagrantfile_created
+
+        finalize_synced_folder_config
+
+        vagrantfile = File.join(vagrant_root, "Vagrantfile")
+        debug("Creating Vagrantfile for #{instance.to_str} (#{vagrantfile})")
+        FileUtils.mkdir_p(vagrant_root)
+        File.open(vagrantfile, "wb") { |f| f.write(render_template) }
+        debug_vagrantfile(vagrantfile)
+        @vagrantfile_created = true
+      end
+
+      def finalize_synced_folder_config
+        config[:synced_folders].map! do |source, destination, options|
+          [
+            File.expand_path(
+              source.gsub("%{instance_name}", instance.name),
+              config[:kitchen_root]
+            ),
+            destination.gsub("%{instance_name}", instance.name),
+            options || "nil"
+          ]
+        end
+      end
+
+      def render_template
+        if File.exists?(template)
+          ERB.new(IO.read(template)).result(binding).gsub(%r{^\s*$\n}, '')
+        else
+          raise ActionFailed, "Could not find Vagrantfile template #{template}"
+        end
+      end
+
+      def template
+        File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
+      end
+
+      def vagrant_ssh_config
+        output = run("vagrant ssh-config", :live_stream => nil)
+        lines = output.split("\n").map do |line|
+          tokens = line.strip.partition(" ")
+          [tokens.first, tokens.last.gsub(/"/, '')]
+        end
+        Hash[lines]
+      end
+
+      def debug_vagrantfile(vagrantfile)
+        if logger.debug?
+          debug("------------")
+          IO.read(vagrantfile).each_line { |l| debug("#{l.chomp}") }
+          debug("------------")
+        end
+      end
+
+      def resolve_config!
+        unless config[:vagrantfile_erb].nil?
+          config[:vagrantfile_erb] =
+            File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
+        end
+        unless config[:pre_create_command].nil?
+          config[:pre_create_command] =
+            config[:pre_create_command].gsub("{{vagrant_root}}", vagrant_root)
+        end
+      end
+
+      def vagrant_version
+        version_string = silently_run("vagrant --version")
+        version_string = version_string.chomp.split(" ").last
+      rescue Errno::ENOENT
+        raise UserError, "Vagrant #{MIN_VER} or higher is not installed." +
+          " Please download a package from #{WEBSITE}."
+      end
+
+      def check_vagrant_version
+        version = vagrant_version
+        if Gem::Version.new(version) < Gem::Version.new(MIN_VER)
+          raise UserError, "Detected an old version of Vagrant (#{version})." +
+            " Please upgrade to version #{MIN_VER} or higher from #{WEBSITE}."
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/vagrant_windows.rb
+++ b/lib/kitchen/driver/vagrant_windows.rb
@@ -20,7 +20,7 @@ require 'fileutils'
 require 'rubygems/version'
 
 require 'kitchen'
-
+require 'kitchen/driver/vagrant_common'
 # Useful VBox Machine Class
 require 'kitchen/provider/machine'
 
@@ -122,74 +122,12 @@ module Kitchen
 
       protected
 
-      WEBSITE = "http://downloads.vagrantup.com/"
-      MIN_VER = "1.1.0"
-
-      default_config :password, "vagrant"
-      default_config :username, "vagrant"
-
-      def run(cmd, options = {})
-        cmd = "echo #{cmd}" if config[:dry_run]
-        run_command(cmd, { :cwd => vagrant_root }.merge(options))
-      end
-
-      def silently_run(cmd)
-        run_command(cmd,
-          :live_stream => nil, :quiet => logger.debug? ? false : true)
-      end
-
-      def run_pre_create_command
-        if config[:pre_create_command]
-          run(config[:pre_create_command], :cwd => config[:kitchen_root])
-        end
-      end
-
-      def vagrant_root
-        @vagrant_root ||= File.join(
-          config[:kitchen_root], %w{.kitchen kitchen-vagrant}, instance.name
-        )
-      end
-
-      def create_vagrantfile
-        return if @vagrantfile_created
-
-        finalize_synced_folder_config
-
-        vagrantfile = File.join(vagrant_root, "Vagrantfile")
-        debug("Creating Vagrantfile for #{instance.to_str} (#{vagrantfile})")
-        FileUtils.mkdir_p(vagrant_root)
-        File.open(vagrantfile, "wb") { |f| f.write(render_template) }
-        debug_vagrantfile(vagrantfile)
-        @vagrantfile_created = true
-      end
-
-      def finalize_synced_folder_config
-        config[:synced_folders].map! do |source, destination, options|
-          [
-            File.expand_path(
-              source.gsub("%{instance_name}", instance.name),
-              config[:kitchen_root]
-            ),
-            destination.gsub("%{instance_name}", instance.name),
-            options || "nil"
-          ]
-        end
-      end
-
-      def render_template
-        if File.exists?(template)
-          ERB.new(IO.read(template)).result(binding).gsub(%r{^\s*$\n}, '')
-        else
-          raise ActionFailed, "Could not find Vagrantfile template #{template}"
-        end
-      end
-
-      def template
-        File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
-      end
-
+      include Kitchen::Driver::VagrantCommon
+      
       def set_winrm_state(state)
-        state[:hostname] = "127.0.0.1"
+        hash = vagrant_ssh_config
+
+        state[:hostname] = hash["HostName"]
         state[:username] = config[:username] if config[:username]
         state[:password] = config[:password] if config[:password]
         refresh_winrm_forwarded_port(state)
@@ -204,41 +142,6 @@ module Kitchen
           Provider::VirtualBox::Machine.new(vagrant_root) do |machine|
             state[:port] = machine.host_port(5985)
           end
-        end
-      end
-
-      def debug_vagrantfile(vagrantfile)
-        if logger.debug?
-          debug("------------")
-          IO.read(vagrantfile).each_line { |l| debug("#{l.chomp}") }
-          debug("------------")
-        end
-      end
-
-      def resolve_config!
-        unless config[:vagrantfile_erb].nil?
-          config[:vagrantfile_erb] =
-            File.expand_path(config[:vagrantfile_erb], config[:kitchen_root])
-        end
-        unless config[:pre_create_command].nil?
-          config[:pre_create_command] =
-            config[:pre_create_command].gsub("{{vagrant_root}}", vagrant_root)
-        end
-      end
-
-      def vagrant_version
-        version_string = silently_run("vagrant --version")
-        version_string = version_string.chomp.split(" ").last
-      rescue Errno::ENOENT
-        raise UserError, "Vagrant #{MIN_VER} or higher is not installed." +
-          " Please download a package from #{WEBSITE}."
-      end
-
-      def check_vagrant_version
-        version = vagrant_version
-        if Gem::Version.new(version) < Gem::Version.new(MIN_VER)
-          raise UserError, "Detected an old version of Vagrant (#{version})." +
-            " Please upgrade to version #{MIN_VER} or higher from #{WEBSITE}."
         end
       end
     end


### PR DESCRIPTION
Hi there,

I was doing some more testing tonight and noticed that all fresh kitchen converges were failing because the hostname was always set to 127.0.0.1. For some reason I missed this the other night. Likely because I was fiddling alot with my config to get everything working. Not sure if if this is intentional and working in your environment. I use Hyper-V but I'm not sure why this would work on vbox. 

Anyways, I have noticed that Vagrant's ssh-config command works even when ssh is not configured at least to get the host name passed on from the provider. So it seems that could be used for winrm as well.

While I was at it and instead of copying the method that parses the ssh-config output I extracted all the common protected methods into their own module and include them in the individual driver classes. I'm still rather new to the Ruby language (long time C# dev and java before that) but I _think_ that is popper form.
