### PR TITLE
we want to allow config precedence over ssh settings. other than host, the ssh settings will not apply to winrm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require "bundler/gem_tasks"
 require 'cane/rake_task'
 require 'tailor/rake_task'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:test)
 
 desc "Run cane to check quality metrics"
 Cane::RakeTask.new
@@ -16,6 +19,6 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task :quality => [:cane, :tailor, :stats]
+task :quality => [:cane, :tailor, :stats, :test]
 
 task :default => [ :quality ]

--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'cane'
   gem.add_development_dependency 'tailor'
   gem.add_development_dependency 'countloc'
+  gem.add_development_dependency 'rspec'
 end

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -47,12 +47,16 @@ module Kitchen
       default_config :provider,
         ENV.fetch('VAGRANT_DEFAULT_PROVIDER', "virtualbox")
 
-      default_config :vm_hostname do |driver|
-        "#{driver.instance.name}.vagrantup.com"
-      end
-
       default_config :box do |driver|
         "opscode-#{driver.instance.platform.name}"
+      end
+
+      default_config :vm_hostname do |driver|
+        driver.instance.name
+      end
+
+      default_config :communicator do |driver|
+        driver.instance.transport.class.name.split('::').last.downcase
       end
 
       default_config :box_url do |driver|
@@ -229,11 +233,30 @@ module Kitchen
         hash = vagrant_ssh_config
 
         state[:hostname] = hash["HostName"]
-        state[:username] = hash["User"]
-        state[:password] = 'vagrant' unless config[:password]
+        state[:username] = config[:username] || hash["User"]
+        state[:password] = config[:password] || 'vagrant'
         state[:ssh_key] = hash["IdentityFile"]
-        state[:port] = hash["Port"]
+        state[:port] = port_from_config
+        if config[:communicator] == "ssh"
+          state[:port] =  hash["Port"]
+        end
         refresh_forwarded_port(state)
+      end
+
+      def port_from_config
+        port = config[:port]
+        if port.nil?
+          guest_port = config[:guest_port] || instance.transport.default_port
+          if !config[:network].empty?
+            forwards = config[:network].select do |net|
+              net[0] == "forwarded_port" && net[1][:guest] == guest_port
+            end
+            forwards.each do |forward|
+              port = forward[1][:host]
+            end
+          end
+        end
+        port || instance.transport.default_port
       end
 
       # Get forwarded_port from Provider

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1,0 +1,173 @@
+require 'kitchen/driver/vagrant'
+require 'yaml'
+
+module Kitchen
+
+  module Driver
+
+    class Testable < Kitchen::Driver::Vagrant
+
+      def initialize(config, ssh_config = {})
+        super(config)
+        @ssh_config = ssh_config
+      end
+
+      def create(state)
+        set_state(state)
+      end
+
+      protected
+
+      def vagrant_ssh_config
+        @ssh_config
+      end
+
+      def refresh_forwarded_port(state)
+      end
+    end
+  end
+end
+
+describe Kitchen::Driver::Vagrant do
+  let(:vagrant_ssh_config) {{
+    'Port' => 22,
+    'HostName' => "hostname",
+    'User' => "user",
+    'IdentityFile' => "key"
+  }}
+
+  subject do
+    parsed = Kitchen::Util.symbolized_hash(YAML.load(yaml))
+    transport = parsed[:transport][:name]
+    instance = double(
+      transport: Kitchen::Transport.for_plugin(transport, parsed),
+      logger: Logger.new(STDOUT)
+    )
+    driver = Kitchen::Driver::Testable.new(parsed[:driver], vagrant_ssh_config)
+    driver.instance = instance
+    driver
+  end
+
+  context "using ssh" do
+    let(:vagrant_ssh_config) {{
+      'Port' => 8888,
+      'HostName' => "hostname",
+      'User' => "user",
+      'IdentityFile' => "key"
+    }}
+    let(:yaml) do
+      <<-EOS
+        transport:
+          name: ssh
+        driver:
+          box: mybox
+      EOS
+    end
+
+    it "uses ssh_config from vagrant" do
+      state = {}
+      subject.create(state)
+
+      expect(state[:port]).to eq 8888
+    end
+  end
+
+  context "using winrm" do
+    context "forwarding to default guest port" do
+      let(:yaml) do
+        <<-EOS
+          transport:
+            name: winrm
+          driver:
+            box: mybox
+            network:
+            - ["forwarded_port", {guest: 5985, host: 55985}]
+        EOS
+      end
+
+      it "sets the port to the forwarded port" do
+        state = {}
+        subject.create(state)
+
+        expect(state[:port]).to eq 55985
+      end
+    end
+
+    context "using a custom port" do
+      let(:yaml) do
+        <<-EOS
+          transport:
+            name: winrm
+          driver:
+            box: mybox
+            port: 9999
+        EOS
+      end
+
+      it "sets the port to the custom port" do
+        state = {}
+        subject.create(state)
+
+        expect(state[:port]).to eq 9999
+      end
+    end
+
+    context "forwarding to a custom guest_port" do
+      let(:yaml) do
+        <<-EOS
+          transport:
+            name: winrm
+          driver:
+            box: mybox
+            guest_port: 7777
+            network:
+            - ["forwarded_port", {guest: 7777, host: 33333}]
+        EOS
+      end
+
+      it "sets the port to the forwarded port" do
+        state = {}
+        subject.create(state)
+
+        expect(state[:port]).to eq 33333
+      end
+    end
+
+    context "specifying a custom guest_port with no forwarding" do
+      let(:yaml) do
+        <<-EOS
+          transport:
+            name: winrm
+          driver:
+            box: mybox
+            guest_port: 7777
+        EOS
+      end
+
+      it "sets the port to the default port" do
+        state = {}
+        subject.create(state)
+
+        expect(state[:port]).to eq 5985
+      end
+    end
+
+    context "no network config" do
+      let(:yaml) do
+        <<-EOS
+          transport:
+            name: winrm
+          driver:
+            box: mybox
+        EOS
+      end
+
+      it "sets the port to the default port" do
+        state = {}
+        subject.create(state)
+
+        expect(state[:port]).to eq 5985
+      end
+    end
+  end
+end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -5,11 +5,21 @@ Vagrant.configure("2") do |c|
 <% if config[:vm_hostname] %>
   c.vm.hostname = "<%= config[:vm_hostname] %>"
 <% end %>
+c.vm.communicator = "<%= config[:communicator] %>"
+<% if config[:port] %>
+  c.<%= config[:communicator] %>.port = <%= config[:port] %>
+<% end %>
+<% if config[:guest_port] %>
+  c.<%= config[:communicator] %>.guest_port = <%= config[:guest_port] %>
+<% end %>
 <% if config[:guest] %>
   c.vm.guest = <%= config[:guest] %>
 <% end %>
 <% if config[:username] %>
-  c.ssh.username = "<%= config[:username] %>"
+  c.<%= config[:communicator] %>.username = "<%= config[:username] %>"
+<% end %>
+<% if config[:password] %>
+  c.<%= config[:communicator] %>.password = "<%= config[:password] %>"
 <% end %>
 <% if config[:ssh_key] %>
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"


### PR DESCRIPTION
I was testing the latest Transform on Hyper-V and VirtualBox tonight and found a problem with Hyper-V. Since all settings are fed from vagrant ssh-config, most were wrong for my box. I use a different username and password than 'vagrant'  and they were not being used and kitchen was trying to talk to winrm on port 22 since that is indeed the port that shows up in ssh-config. We dont see this problem on VirtualBox since it uses a different strategy for getting the port and in my case I do use the standard vagrant user on my virtualbox box but its certainly possible someone else could use a different user.
