### PR TITLE
Use '--provider FOO' (with a space)

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -71,7 +71,7 @@ module Kitchen
         create_vagrantfile
         run_pre_create_command
         cmd = "vagrant up --no-provision"
-        cmd += " --provider=#{config[:provider]}" if config[:provider]
+        cmd += " --provider #{config[:provider]}" if config[:provider]
         run cmd
         set_state(state)
         info("Vagrant instance #{instance.to_str} created.")


### PR DESCRIPTION
For some reason I'm getting this error:
    ---- Begin output of vagrant up --no-provision --provider=virtualbox ----
    STDOUT:
    STDERR: An invalid option was specified. The help for this command
    is available below.

All signs point to the correct argument not having an equals sign.
