### PR TITLE
Gui Console Visibility Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ By default the value is unset, or `nil`. In this case the driver will use the
 Vagrant [default provider][vagrant_default_provider] which at this current time
 is `virtualbox` unless set by `VAGRANT_DEFAULT_PROVIDER` environment variable.
 
+### <a name="config-gui"></a> gui
+
+This is the vm console gui configuration and is used to make the console
+visible/hidden following a create action.
+
+If this value is `nil` or `false` then the console will be hidden, if `true`
+the console will be visble.
+
+This is particularly helpful for debugging Virtualbox Windows guests along with
+adding `clipboard: bidirectional` to the customize section.
+
 ### <a name="config-customize"></a> customize
 
 A **Hash** of customizations to a Vagrant virtual machine.  Each key/value
@@ -136,6 +147,7 @@ driver:
   customize:
     memory: 1024
     cpuexecutioncap: 50
+    clipboard: bidirectional
 ```
 
 will generate a Vagrantfile configuration similar to:

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -35,22 +35,29 @@ c.vm.communicator = "<%= config[:communicator] %>"
 <% end %>
 
   c.vm.provider :<%= config[:provider] %> do |p|
-<% config[:customize].each do |key, value| %>
-  <% case config[:provider]
-     when "virtualbox" %>
-    p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
-  <% when "rackspace", "softlayer" %>
-    p.<%= key %> = "<%= value%>"
-  <% when /^vmware_/ %>
-    <% if key == :memory %>
-      <% unless config[:customize].include?(:memsize) %>
-    p.vmx["memsize"] = "<%= value %>"
+    <% case config[:provider]
+    when "virtualbox" %>
+      <% if config[:gui] %>
+      p.gui = <%= config[:gui] %>
       <% end %>
-    <% else %>
-    p.vmx["<%= key %>"] = "<%= value %>"
+    <% end %>
+
+  <% config[:customize].each do |key, value| %>
+    <% case config[:provider]
+       when "virtualbox" %>
+      p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
+    <% when "rackspace", "softlayer" %>
+      p.<%= key %> = "<%= value%>"
+    <% when /^vmware_/ %>
+      <% if key == :memory %>
+        <% unless config[:customize].include?(:memsize) %>
+      p.vmx["memsize"] = "<%= value %>"
+        <% end %>
+      <% else %>
+      p.vmx["<%= key %>"] = "<%= value %>"
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
   end
 
 end


### PR DESCRIPTION
Salim,

I have found if you spin up multiple windows machines using the kitchen login is very unreliable if you try to connect to more than one machine at a time.  This allows you to make the Virtualbox GUI Console visible by adding 'gui: true' to the driver_config: hash in the '.kitchen.yml'.

Dax
